### PR TITLE
Fix invalid attribute code characters by replacing "&" with "_"

### DIFF
--- a/src/Application/Mapper/Strategy/ClassificationStore/AbstractMapKeyStrategy.php
+++ b/src/Application/Mapper/Strategy/ClassificationStore/AbstractMapKeyStrategy.php
@@ -73,6 +73,8 @@ abstract class AbstractMapKeyStrategy implements MapKeyStrategyInterface
         }
         $code = str_replace(' ', '', str_replace('-', '_', array_map('strtolower', $names)));
         $code = str_replace(['å','ä'], 'a', str_replace('ö', 'o', $code));
+        $code = str_replace("&", "_", $code);
+        
         return $code;
     }
 


### PR DESCRIPTION
Adjusted the magento bridge to not allow invalid characters such as "&" to be allowed within attribute codes and instead be replaced with "_".